### PR TITLE
feat: use MessagePack in RTCDataChannel

### DIFF
--- a/crates/harmion-connect/Cargo.toml
+++ b/crates/harmion-connect/Cargo.toml
@@ -16,8 +16,8 @@ webrtc = "0.13.0"
 thiserror = { workspace = true }
 tracing   = { workspace = true }
 
-tokio = { workspace = true }
-
-warp    = "0.3"
-dashmap = "6.0.1"
+tokio      = { workspace = true }
 tokio-util = "0.7.16"
+
+ntex = "2.15.1"
+rmp-serde = "1.3.0"

--- a/crates/harmion-connect/src/webrtc/simple.rs
+++ b/crates/harmion-connect/src/webrtc/simple.rs
@@ -58,8 +58,8 @@ pub(super) enum PeerError {
     PeerNotConnected,
     #[error("Serialization error(Message): {0}")]
     MessageSerialize(#[from] rmp_serde::encode::Error),
-    #[error("(De)Serialization error(SDP): {0}")]
-    SDPSerialize(#[from] serde_json::Error),
+    #[error("SDP JSON serialization/deserialization error: {0}")]
+    SDPJson(#[from] serde_json::Error),
     #[error("Data channel not available")]
     DataChannelNotAvailable,
     #[error("Connection failed")]

--- a/crates/harmion-connect/src/webrtc/simple.rs
+++ b/crates/harmion-connect/src/webrtc/simple.rs
@@ -481,7 +481,7 @@ impl<S: PeerConnectingState> Peer<S> {
 
 impl Peer<Connected> {
     pub async fn send(&self, message: Message) -> Result<(), PeerError> {
-        let message = rmp_serde::to_vec(&InnerMessage::Message(message))?; // rmp?
+        let message = rmp_serde::to_vec(&InnerMessage::Message(message))?;
 
         let dc_guard = self.dc.read().await;
         let dc = dc_guard


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Real-time messaging now uses a compact binary encoding for data channels, improving efficiency; clients must update to remain compatible.
  - Sending APIs now accept structured message payloads instead of plain text.
- Chores
  - Updated networking and serialization dependencies; removed unused dependencies.
- Tests
  - Tests updated to align with the new binary message format and sending APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->